### PR TITLE
fix gcc 12 or above compiling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It can handle sequences consisting of terabytes of input data (gzipped or not, i
  - any C++ compiler supporting the C++11 standard
  - CMake version 2.6 or plus
  - zlib 
- 
+
 # How to install:
 ```sh
 cd ${PROJECT_ROOT_DIRECTORY}  
@@ -27,9 +27,7 @@ brew install gcc@8
 GCCPATH=$(ls /usr/local/Cellar/gcc/*/bin/)
 export PATH="${GCCPATH}:${PATH}"
 # Set CC CXX to /usr/local/Cellar/gcc/*/bin/* as necessary
-# Then run cmake as above (a GUI for cmake may also be available for MacOS), for example on newest MacOS (M1 or later)
-CXX=/opt/homebrew/Cellar/gcc/13.2.0/bin/g++-13 CC=/opt/homebrew/Cellar/gcc/13.2.0/bin/gcc-13 cmake  -DCMAKE_BUILD_TYPE=Release ../
-CXX=/opt/homebrew/Cellar/gcc/13.2.0/bin/g++-13 CC=/opt/homebrew/Cellar/gcc/13.2.0/bin/gcc-13 make -j 8
+# Then run cmake as above (a GUI for cmake may also be available for MacOS)
 
 ```
 
@@ -58,7 +56,7 @@ Basically, compression of a genome is done as follows.
  1. All k-mers of each genome are selected and then transformed into hash values.
  2. The range of all possible hash values are partitioned into some bins.
  3. The smallest hash value in each bin is selected.
- 4. If a bin is empty (i.e., has no hash values), then the smallest hash value from the next bin is picked. The definition of the next bin is proposed by Shrivastava.
+ 4. If a bin is empty (i.e., has no hash values), then the smallest hash value from the next bin is picked. The definition of the next bin is proposed by Shrivastava 2017. Another densification strategy is to map reversely from non-empty bins to empty bins and choose the smallest hash value from non-empty bin to fill the empty bin, as proposed by Mai et.al. 2020. This new densification strategy has a worse case O(k*log(k)) complexity  while Shrivastava 2017 has a O(k^2) worse case complexity.
  5. The lowest (i.e., least significant) b-bits of each hash value are picked to form the signature of the genome.
 
 Two genomes are compared by simply performing b XOR opeations for b bit positions, followed by (b-1) AND operations for these b bit positions. 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ brew install gcc@8
 GCCPATH=$(ls /usr/local/Cellar/gcc/*/bin/)
 export PATH="${GCCPATH}:${PATH}"
 # Set CC CXX to /usr/local/Cellar/gcc/*/bin/* as necessary
-# Then run cmake as above (a GUI for cmake may also be available for MacOS)
+# Then run cmake as above (a GUI for cmake may also be available for MacOS), for example on newest MacOS (M1 or later)
+CXX=/opt/homebrew/Cellar/gcc/13.2.0/bin/g++-13 CC=/opt/homebrew/Cellar/gcc/13.2.0/bin/gcc-13 cmake  -DCMAKE_BUILD_TYPE=Release ../
+CXX=/opt/homebrew/Cellar/gcc/13.2.0/bin/g++-13 CC=/opt/homebrew/Cellar/gcc/13.2.0/bin/gcc-13 make -j 8
+
 ```
 
 # How to run:

--- a/src/bindash.cpp
+++ b/src/bindash.cpp
@@ -156,7 +156,7 @@ void entity_init(Entity &entity, CBuf &cbuf, const std::string &entityname, cons
 			if (cbuf.ceof()) { break; }
 			hashupdate2(cbuf, signs, hf, hfrc, args.isstrandpreserved, binsize);
 		}
-		uint64_t res = UINT64_MAX;
+		int res = 0;
 		if (1 == args.dens){
 			// use optimal densification
 			res = opt_densify(signs);
@@ -164,7 +164,7 @@ void entity_init(Entity &entity, CBuf &cbuf, const std::string &entityname, cons
 			// use reverse optimal densification, or faster densification
 			res = revopt_densify(signs);
 		}
-		if (res != UINT64_MAX) {
+		if (res != 0) {
 			std::cerr << "Warning: the genome " << entityname << " is densified with flag " << res <<  std::endl;
 		}
 		genome_size = estimate_genome_size2(signs, args.sketchsize64);

--- a/src/bindash.cpp
+++ b/src/bindash.cpp
@@ -34,6 +34,7 @@
 #include <set>
 #include <sstream>
 #include <tuple>
+#include <array>
 #include <vector>
 
 #include <assert.h>
@@ -358,7 +359,7 @@ void cmddist(bool tCLUSTER, bool tNNEIGHBORS,
 		}
 
 	} else {
-		typedef std::tuple<double, double, size_t, size_t, size_t, size_t> hit_t;
+		using hit_t = std::tuple<double, double, long unsigned int, long unsigned int, long unsigned int, long unsigned int>;
 		std::array<std::priority_queue<hit_t>, ISIZE> tophits_arr;
 		for (size_t i2 = 0; i2 < entities1.size(); i2 += ISIZE) {
 			size_t i2max = MIN(i2 + ISIZE, entities1.size());

--- a/src/bindash.cpp
+++ b/src/bindash.cpp
@@ -34,9 +34,9 @@
 #include <set>
 #include <sstream>
 #include <tuple>
-#include <array>
 #include <vector>
-
+#include <array>
+#include <queue>
 #include <assert.h>
 #include <float.h>
 #include <limits.h>
@@ -359,7 +359,7 @@ void cmddist(bool tCLUSTER, bool tNNEIGHBORS,
 		}
 
 	} else {
-		using hit_t = std::tuple<double, double, long unsigned int, long unsigned int, long unsigned int, long unsigned int>;
+		typedef std::tuple<double, double, size_t, size_t, size_t, size_t> hit_t;
 		std::array<std::priority_queue<hit_t>, ISIZE> tophits_arr;
 		for (size_t i2 = 0; i2 < entities1.size(); i2 += ISIZE) {
 			size_t i2max = MIN(i2 + ISIZE, entities1.size());

--- a/src/bindash.cpp
+++ b/src/bindash.cpp
@@ -156,7 +156,8 @@ void entity_init(Entity &entity, CBuf &cbuf, const std::string &entityname, cons
 			if (cbuf.ceof()) { break; }
 			hashupdate2(cbuf, signs, hf, hfrc, args.isstrandpreserved, binsize);
 		}
-		int res = 0;
+		// Declaration of res as an integer
+		int res;
 		if (1 == args.dens){
 			// use optimal densification
 			res = opt_densify(signs);

--- a/src/bindash.cpp
+++ b/src/bindash.cpp
@@ -48,7 +48,7 @@
 #include <string.h>
 #include <time.h>
 
-#define VERSION "0.2.1"
+#define VERSION "0.3.0"
 
 /* TODO:
  * Potential improvement to be made: CACHE_AWARE nearest neighbor search (may involve substantial additional coding).
@@ -156,8 +156,15 @@ void entity_init(Entity &entity, CBuf &cbuf, const std::string &entityname, cons
 			if (cbuf.ceof()) { break; }
 			hashupdate2(cbuf, signs, hf, hfrc, args.isstrandpreserved, binsize);
 		}
-		int res = densifybin(signs);
-		if (res != 0) {
+		uint64_t res = UINT64_MAX;
+		if (1 == args.dens){
+			// use optimal densification
+			res = opt_densify(signs);
+		} else if (2 == args.dens){
+			// use reverse optimal densification, or faster densification
+			res = revopt_densify(signs);
+		}
+		if (res != UINT64_MAX) {
 			std::cerr << "Warning: the genome " << entityname << " is densified with flag " << res <<  std::endl;
 		}
 		genome_size = estimate_genome_size2(signs, args.sketchsize64);

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -63,6 +63,7 @@ public:
 	std::string listfname = "-";
 	size_t kmerlen = 21;
 	int minhashtype = 2;
+	int dens = 1;
 	size_t nthreads = 1;
 	std::string outfname = "";
 	uint64_t randseed = 41; //0x3355557799AACCULL;
@@ -93,6 +94,7 @@ void verifycompatible(const Sketchargs &args1, const Sketchargs &args2, std::str
 	isok &= areequals_printerrifnot(args1.isstrandpreserved, args2.isstrandpreserved, "--isstrandpreserved", infname1, infname2);
 	isok &= areequals_printerrifnot(args1.kmerlen, args2.kmerlen, "--kmerlen", infname1, infname2);
 	isok &= areequals_printerrifnot(args1.minhashtype, args2.minhashtype, "--minhashtype", infname1, infname2);
+	isok &= areequals_printerrifnot(args1.dens, args2.dens, "--dens", infname1, infname2);
 	isok &= areequals_printerrifnot(args1.randseed, args2.randseed, "--randseed", infname1, infname2);
 	isok &= areequals_printerrifnot(args1.sketchsize64, args2.sketchsize64, "--sketchsize64", infname1, infname2);
 	if (!isok) { exit(2); }
@@ -111,6 +113,9 @@ int Sketchargs::usage(const int argc, const char *const *argv) {
 	          << "    \"Path-to-a-sequence-file(F) <TAB> [genome-name(G) <TAB> number-of-consecutive-sequences(N) ...]\".\n"
 	          << "    If only F is provided, then use F as G and let N be the number of sequences in N [" << listfname << "]\n\n";
 	std::cerr << "  --nthreads : This many threads will be spawned for processing. [" << nthreads << "]\n\n";
+	std::cerr << "  --dens : This will use a specific densification strategy.\n" 
+				 "		1 means optimal densification, default. \n"
+				 "		2 means reverse optimal densification. [" << dens << "]\n\n";
 	std::cerr << "  --minhashtype : Type of minhash.\n" 
 	          << "    -1 means perfect hash function for nucleotides where 5^(kmerlen) < 2^63.\n" 
 	          << "    0 means one hash-function with multiple min-values.\n"
@@ -148,6 +153,7 @@ int Sketchargs::write(const std::string &systime_began, const std::string &systi
 	file << std::boolalpha << "--isstrandpreserved=" << isstrandpreserved << "\n";
 	file << "--kmerlen=" << kmerlen << "\n";
 	file << "--listfname=" << listfname << "\n";
+	file << "--dens=" << dens << "\n";
 	file << "--minhashtype=" << minhashtype << "\n";
 	file << "--nthreads=" << nthreads << "\n";
 	file << "--outfname=" << outfname << "\n";
@@ -225,6 +231,7 @@ int Sketchargs::_parse(std::string arg) {
 	else if ("--isstrandpreserved" == key) { issval >> std::boolalpha >> isstrandpreserved; }
 	else if ("--kmerlen" ==  key) { issval >> kmerlen; }
 	else if ("--listfname" ==  key) { issval >> listfname; }
+	else if ("--dens" ==  key) { issval >> dens; }
 	else if ("--minhashtype" ==  key) { issval >> minhashtype; }
 	else if ("--nthreads" == key) { issval >> nthreads; }
 	else if ("--outfname" == key) { issval >> outfname; }

--- a/src/hashutils.hpp
+++ b/src/hashutils.hpp
@@ -105,13 +105,23 @@ uint32_t murmur_hash(uint32_t value, uint32_t seed) {
   year={2020}
 }
 */
-int revopt_densify(std::vector<uint64_t>& v) {
-    size_t size = v.size();
+int revopt_densify(std::vector<uint64_t>& signs) {
+
+	uint64_t minval = UINT64_MAX;
+	uint64_t maxval = 0;
+	for (auto sign : signs) { 
+		minval = MIN(minval, sign);
+		maxval = MAX(maxval, sign);
+	}
+	if (UINT64_MAX != maxval) { return 0; }
+	if (UINT64_MAX == minval) { return -1; }
+
+    size_t size = signs.size();
     std::unordered_set<size_t> E; // Set of empty bins
 
     // Initial identification of empty bins, we use UINT64_MAX as unassigned bins
     for (size_t i = 0; i < size; ++i) {
-        if (v[i] == UINT64_MAX) {
+        if (signs[i] == UINT64_MAX) {
             E.insert(i);
         }
     }
@@ -119,10 +129,10 @@ int revopt_densify(std::vector<uint64_t>& v) {
     size_t alpha = 0;
     while (!E.empty()) {
         for (size_t j = 0; j < size; ++j) {
-            if (v[j] != UINT64_MAX) {
+            if (signs[j] != UINT64_MAX) {
                 size_t i = murmur_hash(j, alpha) % size;
                 if (E.find(i) != E.end()) {
-                    v[i] = v[j]; // Directly update the bin in the input vector
+                    signs[i] = signs[j]; // Directly update the bin in the input vector
                     E.erase(i);
                     if (E.empty()) break;
                 }

--- a/src/murmur3.h
+++ b/src/murmur3.h
@@ -1,0 +1,307 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the
+// public domain. The author hereby disclaims copyright to this source
+// code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+#include <stdint.h>
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+#ifdef __GNUC__
+#define FORCE_INLINE __attribute__((always_inline)) inline
+#else
+#define FORCE_INLINE inline
+#endif
+
+static FORCE_INLINE uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+static FORCE_INLINE uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+#define getblock(p, i) (p[i])
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+static FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+static FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+
+inline void MurmurHash3_x86_32 (const void *key, int len, uint32_t seed, void *out)
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+  int i;
+
+  uint32_t h1 = seed;
+
+  uint32_t c1 = 0xcc9e2d51;
+  uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+inline void MurmurHash3_x86_128(const void *key, int len, uint32_t seed, void *out)
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+  int i;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  uint32_t c1 = 0x239b961b; 
+  uint32_t c2 = 0xab0e9789;
+  uint32_t c3 = 0x38b34ae5; 
+  uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i*4+0);
+    uint32_t k2 = getblock(blocks,i*4+1);
+    uint32_t k3 = getblock(blocks,i*4+2);
+    uint32_t k4 = getblock(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+inline void MurmurHash3_x64_128(const void *key, int len, uint32_t seed, void *out)
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+  int i;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock(blocks,i*2+0);
+    uint64_t k2 = getblock(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= (uint64_t)(tail[14]) << 48;
+  case 14: k2 ^= (uint64_t)(tail[13]) << 40;
+  case 13: k2 ^= (uint64_t)(tail[12]) << 32;
+  case 12: k2 ^= (uint64_t)(tail[11]) << 24;
+  case 11: k2 ^= (uint64_t)(tail[10]) << 16;
+  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8;
+  case  9: k2 ^= (uint64_t)(tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56;
+  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48;
+  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40;
+  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32;
+  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24;
+  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16;
+  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8;
+  case  1: k1 ^= (uint64_t)(tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_


### PR DESCRIPTION
do not use typedef but use. Tested on Linux, MacOS (use gcc on macOS instead of default clang as compile).